### PR TITLE
Add is_debug() helper function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,7 @@ pub mod xml;
 
 use std::borrow::Cow;
 use std::collections::HashMap;
+use std::env;
 
 pub use self::xml::XMLWriter;
 
@@ -608,4 +609,12 @@ pub enum ItemType {
     ///
     /// Similar to `File` but skips the check to ensure the file exists.
     FileSkipCheck
+}
+
+/// Returns true if user has Alfred's workflow debug console open.
+pub fn is_debug() -> bool {
+    match env::var("alfred_debug") {
+        Ok(val) => val == "1",
+        Err(_) => false,
+    }
 }


### PR DESCRIPTION
I use this a lot with Alfred libraries in other languages to determine if it's ok to output debug information or not, which would otherwise screw up Alfred's output parsing.

I wasn't quite sure where to put this however, so I just threw it directly into the main module. Hope that's ok.

Thanks for the lib!